### PR TITLE
All text_area needs to have form-control to be bootstrap like. make s…

### DIFF
--- a/app/views/camps/_form.haml
+++ b/app/views/camps/_form.haml
@@ -314,34 +314,33 @@
   %br
   .header-heading
     = t("form_project_management")
-  .combo
+  .h3
     = form.label t("form_project_management_crew")
-    %br
-    = t("form_project_management_crew_desc")
+  = t("form_project_management_crew_desc")
   
-  #responsibles.col-md-12
+  #responsibles
     = form.fields_for :people do |person|
       = render 'person_fields', :f => person, :camp_id => @camp.id
  
   .links.col-xs-12
-    = link_to_add_association t('add_a_new_person'), form, :people, render_options: { locals: { camp_id: @camp.id } }, class: 'btn btn-default'
+    = link_to_add_association t('add_a_new_person'), form, :people, render_options: { locals: { camp_id: @camp.id } }, class: 'btn btn-success'
     %br
     %br
 
-  .combo
+  .combo.col-xs-12
     = form.label :projectmgmt_is_theme_camp_dream
     = form.check_box :projectmgmt_is_theme_camp_dream, data: {show:'#theme_camp_related_desc'}
 
-  #theme_camp_related_desc
+  #theme_camp_related_desc.col-xs-12
     .combo
       = form.label :projectmgmt_is_dream_near_theme_camp
       = form.check_box :projectmgmt_is_dream_near_theme_camp
 
-  .combo
+  .combo.col-xs-12
     = form.label :projectmgmt_dream_pre_construction_site
     %br
     = t("form_project_management_dream_pre_construction_site_guidetext_html")
-    = form.text_area :projectmgmt_dream_pre_construction_site, :max_length => 4096
+    = form.text_area :projectmgmt_dream_pre_construction_site, :max_length => 4096, class: "form-control"
 
   %br
   %br


### PR DESCRIPTION
…ure that we are using col-xs-12 with fields below the add person so rows wont break. Changed add person button to pink

@basels Notice that all text_area and other input fields needs to have 'form-control' class to be bootstrap like.