### PR TITLE
Feat/add safety file comments to dream show

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -38,6 +38,7 @@ CREW_SIZE=true
 PERSON_EARLY_ARRIVAL=true
 PERSON_HAS_TICKET=true
 SHOW_POINT_OF_CONTACT=true
+SHOW_SAFETY_FILE_COMMENTS=true
 
 # Recaptcha - only activated on production obtain a key - https://www.google.com/recaptcha/admin
 RECAPTCHA=false

--- a/README.md
+++ b/README.md
@@ -123,3 +123,9 @@ We've added the ability to show a contact person from art-department for the dre
 
 You will need to set the following env var:
 * `SHOW_POINT_OF_CONTACT=true`
+
+## Ability to Show/Edit Safety File Comments
+We've added the ability to show safety file comments for the dream-creator in the dream page. This field is editable by admin/guide users only.
+
+You will need to set the following env var:
+* `SHOW_SAFETY_FILE_COMMENTS=true`

--- a/app/views/camps/_edit_safety_file_comments.haml
+++ b/app/views/camps/_edit_safety_file_comments.haml
@@ -1,5 +1,5 @@
 = simple_form_for @camp, :html => {:dir => I18n.t(:html_direction), :id => 'camp-form' } do |form|
   .combo
-    = form.text_field :safety_file_comments, :maxlength => 4096, :class => "form-control"
+    = form.input :safety_file_comments, :maxlength => 4096, as: 'text', :class => "form-control"
   .submit
     = form.submit t(:dream_safety_file_comments_update), id: 'done-camp', class: 'btn btn-success'

--- a/app/views/camps/_edit_safety_file_comments.haml
+++ b/app/views/camps/_edit_safety_file_comments.haml
@@ -1,0 +1,5 @@
+= simple_form_for @camp, :html => {:dir => I18n.t(:html_direction), :id => 'camp-form' } do |form|
+  .combo
+    = form.text_field :safety_file_comments, :maxlength => 4096, :class => "form-control"
+  .submit
+    = form.submit t(:dream_safety_file_comments_update), id: 'done-camp', class: 'btn btn-success'

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -452,22 +452,22 @@
 
         <% if Rails.configuration.x.firestarter_settings["show_safety_file_comments"] && (current_user && ((@camp.creator == current_user) || (current_user.guide || current_user.admin))) %>
         <div class="safety-file-comments">
-            <ul>
-                <div class="panel panel-default">
-                    <div class="panel-heading"><h2 class="header-sub-heading"><%=t :dream_safety_file_comments_title %></h2></div>
-                    <div class="panel-body">
-                    <% if @camp.creator == current_user %>
-                        <% if  @camp.safety_file_comments.to_s == '' %>
-                            <%=t :dream_safety_file_comments_nop_message %>
-                        <% else %>
-                            <%= @camp.safety_file_comments %>
-                        <% end %>
-                    <% elsif current_user.guide || current_user.admin %>
-                        <%= render 'edit_safety_file_comments' %>
-                    <% end %>
-                    </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h2 class="header-sub-heading"><%=t :dream_safety_file_comments_title %></h2>
                 </div>
-            </ul>
+                <div class="panel-body">
+                <% if @camp.creator == current_user %>
+                    <% if @camp.safety_file_comments.blank? %>
+                        <%= t :dream_safety_file_comments_nop_message %>
+                    <% else %>
+                        <%= simple_format @camp.safety_file_comments %>
+                    <% end %>
+                <% elsif current_user.guide || current_user.admin %>
+                    <%= render 'edit_safety_file_comments' %>
+                <% end %>
+                </div>
+            </div>
         </div> <!-- safety-file-comments -->
         <% end %>
 

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -450,6 +450,27 @@
 
         </div> <!-- creation-info -->
 
+        <% if Rails.configuration.x.firestarter_settings["show_safety_file_comments"] && (current_user && ((@camp.creator == current_user) || (current_user.guide || current_user.admin))) %>
+        <div class="safety-file-comments">
+            <ul>
+                <div class="panel panel-default">
+                    <div class="panel-heading"><h2 class="header-sub-heading"><%=t :dream_safety_file_comments_title %></h2></div>
+                    <div class="panel-body">
+                    <% if @camp.creator == current_user %>
+                        <% if  @camp.safety_file_comments.to_s == '' %>
+                            <%=t :dream_safety_file_comments_nop_message %>
+                        <% else %>
+                            <%= @camp.safety_file_comments %>
+                        <% end %>
+                    <% elsif current_user.guide || current_user.admin %>
+                        <%= render 'edit_safety_file_comments' %>
+                    <% end %>
+                    </div>
+                </div>
+            </ul>
+        </div> <!-- safety-file-comments -->
+        <% end %>
+
         <% if Rails.configuration.x.firestarter_settings["safetybag"] && (current_user&.guide || (@camp.creator == current_user))%>
             <div class="panel panel-default">
                 <div class="panel-heading"><b><%=t :form_extra_team_member_head %></b></div>

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -454,7 +454,7 @@
         <div class="safety-file-comments">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                  <h2 class="header-sub-heading"><%=t :dream_safety_file_comments_title %></h2>
+                  <h2 class="header-sub-heading"><%=t Camp.human_attribute_name("safety_file_comments") %></h2>
                 </div>
                 <div class="panel-body">
                 <% if @camp.creator == current_user %>

--- a/config/firestarter_settings.yml
+++ b/config/firestarter_settings.yml
@@ -33,6 +33,7 @@ defaults: &defaults
   disable_edit_budget: <%= ENV['disable_edit_budget'] or false %>
   google_drive_integration: <%= ENV['GOOGLE_DRIVE_INTEGRATION'] or false %>
   show_point_of_contact: <%= ENV['SHOW_POINT_OF_CONTACT'] or false %>
+  show_safety_file_comments: <%= ENV['SHOW_SAFETY_FILE_COMMENTS'] or false %>
   recaptcha: <%= ENV['RECAPTCHA'] or false %>
 
 development:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,9 @@ en:
   form_dream_website_short: The dream website
   
   form_dream_point_of_contact_email: Your contact person from Art Department
+  dream_safety_file_comments_title: Safety File Comments
+  dream_safety_file_comments_nop_message: Hurray! Nothing for you to update right now...
+  dream_safety_file_comments_update: Update Comments
 
   form_project_management: Project Management
   form_project_management_crew: Team Members

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,6 @@ en:
   form_dream_website_short: The dream website
   
   form_dream_point_of_contact_email: Your contact person from Art Department
-  dream_safety_file_comments_title: Safety File Comments
   dream_safety_file_comments_nop_message: Hurray! Nothing for you to update right now...
   dream_safety_file_comments_update: Update Comments
 
@@ -655,6 +654,7 @@ en:
         projectmgmt_is_theme_camp_dream: :form_project_management_is_theme_camp_dream
         projectmgmt_is_dream_near_theme_camp: :form_project_management_is_dream_near_theme_camp
         projectmgmt_dream_pre_construction_site: :form_project_management_dream_pre_construction_site
+        safety_file_comments: Safety File Comments
       person: &person
         name: Name
         email: Email

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -102,6 +102,9 @@ he:
   form_dream_website_short: "אתר החלום"
 
   form_dream_point_of_contact_email: "איש הקשר שלכם ממחלקת קשרי אמנים"
+  dream_safety_file_comments_title: "הערות תיק בטיחות"
+  dream_safety_file_comments_nop_message: "הידד! אין לך מה לעדכן כרגע..."
+  dream_safety_file_comments_update: "עדכן הערות"
 
   form_project_management: "ניהול הפרויקט"
   form_project_management_crew: "חברי הצוות ובעלי תפקידים"
@@ -605,6 +608,7 @@ he:
         projectmgmt_is_dream_near_theme_camp: :form_project_management_is_dream_near_theme_camp
         projectmgmt_dream_pre_construction_site: :form_project_management_dream_pre_construction_site
         dream_point_of_contact_email: :form_dream_point_of_contact_email
+        safety_file_comments: :dream_safety_file_comments_title
         google_drive_folder_path: תיקייה בדרייב
         google_drive_budget_file_path: מסמך תקציב
         en_name: שם באנגלית

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -102,7 +102,6 @@ he:
   form_dream_website_short: "אתר החלום"
 
   form_dream_point_of_contact_email: "איש הקשר שלכם ממחלקת קשרי אמנים"
-  dream_safety_file_comments_title: "הערות תיק בטיחות"
   dream_safety_file_comments_nop_message: "הידד! אין לך מה לעדכן כרגע..."
   dream_safety_file_comments_update: "עדכן הערות"
 
@@ -608,7 +607,7 @@ he:
         projectmgmt_is_dream_near_theme_camp: :form_project_management_is_dream_near_theme_camp
         projectmgmt_dream_pre_construction_site: :form_project_management_dream_pre_construction_site
         dream_point_of_contact_email: :form_dream_point_of_contact_email
-        safety_file_comments: :dream_safety_file_comments_title
+        safety_file_comments: "הערות תיק בטיחות"
         google_drive_folder_path: תיקייה בדרייב
         google_drive_budget_file_path: מסמך תקציב
         en_name: שם באנגלית

--- a/db/migrate/20170211082722_add_safety_file_comments_to_dream.rb
+++ b/db/migrate/20170211082722_add_safety_file_comments_to_dream.rb
@@ -1,0 +1,5 @@
+class AddSafetyFileCommentsToDream < ActiveRecord::Migration
+  def change
+    add_column :camps, :safety_file_comments, :string, :limit => 4096
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170122213524) do
+ActiveRecord::Schema.define(version: 20170211082722) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     :index=>{:name=>"index_active_admin_comments_on_namespace"}
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 20170122213524) do
     t.string   "en_name",                                                  :limit=>64
     t.string   "en_subtitle",                                              :limit=>255
     t.string   "dream_point_of_contact_email",                             :limit=>64
+    t.string   "safety_file_comments",                                     :limit=>4096
   end
 
   create_table "grants", force: :cascade do |t|


### PR DESCRIPTION
related to https://github.com/Midburn/dreams/issues/77

2 issues are still open here:
@rootux, @sh0oki

- For some reason when the admin/guide submits the comments sub-form it always redirects to the edit page instead of the show page (even though it's submitted using id: 'done-camp'...)
- I would like the text field to be a bit 'longer downwards', how do I do that while still using the form-ctrl class...