### PR TITLE
Revert "If two mangaers exist in a camp, only show one in ActiveAdmin (to remove double rows per camp)"

### DIFF
--- a/app/models/camp.rb
+++ b/app/models/camp.rb
@@ -140,7 +140,6 @@ class Camp < ActiveRecord::Base
         .joins("LEFT JOIN people_roles pr ON (pr.role_id = roles.id)")
         .where('people.id = pr.person_id')
         .select('people.name manager_name, people.email manager_email, people.phone_number manager_phone')
-        .group('camps.id')
   }
 
   scope :displayed_with_tags, -> {


### PR DESCRIPTION
Reverts Midburn/dreams#164