### PR TITLE
Add ability to hide create-dream-button by setting env var

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -24,6 +24,7 @@ IMPORT_CSV_URL=''
 DISABLE_EDIT_BUDGET=false
 DISABLE_EDIT_SAFETYBAG=false
 DISABLE_OPEN_NEW_DREAM=false
+HIDE_CREATE_DREAM_BUTTON=false
 EMAIL_FROM='galbra@gmail.com'
 GOOGLE_APPS_SCRIPT='google-apps-script-id-for-drive-sync'
 GOOGLE_APPS_NAME='google-apps-script-app-name'

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ You will need to set the following env var:
 If at some stage you will want to prevent the dream creators from updating a dream you can set this global env variable to do so:
 * `DISABLE_EDITING_DREAM=true`
 
+## Ability to Hide 'Create Dream' Button
+If at some stage you wish to hide the 'Create Dream' button (where dream-creation is still available by a direct link) you can set this global env variable to do so:
+* `HIDE_CREATE_DREAM_BUTTON=true`
+
 # Events
 Each year we have new dreams.
 We need to update each year by setting the `default_event` parameter in the `application.rb` file

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,10 +17,10 @@
               <%= link_to "עברית", :lang=>'he'%>
             <% end %>
             <%= link_to t("top_headline_dreams"), '/' %>
-            
+
             <%= link_to t("top_headline_faq"), '/pages/faq-'+I18n.locale.to_s %>
             <%= link_to t("how_can_i_help_title"), howcanihelp_path %>
-            <% if user_signed_in? and !Rails.application.config.x.firestarter_settings['disable_open_new_dream'] and Lockdown.instance.allowed?('submit_dream') %>
+            <% if user_signed_in? and !Rails.application.config.x.firestarter_settings['hide_create_dream_button'] and !Rails.application.config.x.firestarter_settings['disable_open_new_dream'] and Lockdown.instance.allowed?('submit_dream') %>
               <%= link_to t("register_creation_menu"), new_camp_path %>
             <% end %>
             <% if !user_signed_in? %>

--- a/config/firestarter_settings.yml
+++ b/config/firestarter_settings.yml
@@ -28,6 +28,7 @@ defaults: &defaults
   person_early_arrival:  <%= ENV['PERSON_EARLY_ARRIVAL'] or false %>
   person_has_ticket:  <%= ENV['PERSON_HAS_TICKET'] or false %>
   multi_lang_support: <%= ENV['MULTI_LANG_SUPPORT'] or false %>
+  hide_create_dream_button: <%= ENV['HIDE_CREATE_DREAM_BUTTON'] or false %>
   disable_open_new_dream: <%= ENV['disable_open_new_dream'] or false %>
   disable_edit_safetybag: <%= ENV['disable_edit_safetybag'] or false %>
   disable_edit_budget: <%= ENV['disable_edit_budget'] or false %>


### PR DESCRIPTION
We need to hide the "create-dream" button to allow only users with direct-link to dream-creation to be able to submit and create new dreams.

Flow should be:
Artists who want to create dreams first submit the google-form of "I have an idea" and then get a reply of their specific art-communication-point-of-contact (angel) with additional details. From now on this email will contain a direct link to dream-creation.

![art_comm_d](https://user-images.githubusercontent.com/24419989/34460523-bae15e6e-ee19-11e7-8cfc-a7cd7f16baa5.jpg)
