### PR TITLE
Setting default image for camp

### DIFF
--- a/app/assets/stylesheets/forms.css.scss
+++ b/app/assets/stylesheets/forms.css.scss
@@ -82,6 +82,10 @@
   &:active {
     background: darken($c-blue, 10%);
   }
+
+  &:disabled {
+    background: darken($c-gray, 10%);
+  }
 }
 
 .granting_button {

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -45,6 +45,15 @@ class ImagesController < ApplicationController
     end
   end
 
+  def set_default_image
+    @image = Image.find_by_id(params[:id])
+    @camp = Camp.find(camp_id)
+    # TODO
+    Rails.logger.debug("Setting image #{@image.id} as default for camp #{@camp.id}")
+    redirect_to camp_images_path(camp_id: @camp_id)
+  end
+
+
   def camp_id
     @camp_id = params[:camp_id]
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -46,10 +46,7 @@ class ImagesController < ApplicationController
   end
 
   def set_default_image
-    @image = Image.find_by_id(params[:id])
-    @camp = Camp.find(camp_id)
-    # TODO
-    Rails.logger.debug("Setting image #{@image.id} as default for camp #{@camp.id}")
+    Camp.find(@camp_id).update(:default_image_id => params[:id])
     redirect_to camp_images_path(camp_id: @camp_id)
   end
 

--- a/app/models/camp.rb
+++ b/app/models/camp.rb
@@ -12,6 +12,7 @@ class Camp < ActiveRecord::Base
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
   has_many :images #, :dependent => :destroy
+  belongs_to :default_image, :class_name => "Image", :foreign_key => :default_image_id
   has_many :grants
   has_many :people, class_name: 'Person'
   has_many :roles, through: :people

--- a/app/views/camps/_list.html.erb
+++ b/app/views/camps/_list.html.erb
@@ -12,7 +12,7 @@
                 <div class="panel panel-info">
                     <div class="panel-body camp-index">
                         <% if camp.images.any? %>
-                            <%= image_tag(camp.images.first.attachment.url(:square), :class => "grow") %>
+                            <%= image_tag(camp.default_image.attachment.url(:square), :class => "grow") %>
                         <% else %>
                             <%= image_tag('bsb_placeholder_square.jpg' , :class => "grow") %>
                         <% end %>

--- a/app/views/camps/_list.html.erb
+++ b/app/views/camps/_list.html.erb
@@ -12,8 +12,7 @@
                 <div class="panel panel-info">
                     <div class="panel-body camp-index">
                         <% if camp.images.any? %>
-				<%= image_tag(camp.images.first.attachment.url(:square), :class => "gr
-		  ow") %>
+                            <%= image_tag(camp.images.first.attachment.url(:square), :class => "grow") %>
                         <% else %>
                             <%= image_tag('bsb_placeholder_square.jpg' , :class => "grow") %>
                         <% end %>

--- a/app/views/camps/_list_chronicles.html.erb
+++ b/app/views/camps/_list_chronicles.html.erb
@@ -12,8 +12,7 @@
                 <div class="panel panel-info">
                     <div class="panel-body camp-index">
                         <% if camp.images.any? %>
-				<%= image_tag(camp.images.first.attachment.url(:square), :class => "gr
-		  ow") %>
+                            <%= image_tag(camp.default_image.attachment.url(:square), :class => "grow") %>
                         <% else %>
                             <%= image_tag('bsb_placeholder_square.jpg' , :class => "grow") %>
                         <% end %>

--- a/app/views/howcanihelp/index.html.erb
+++ b/app/views/howcanihelp/index.html.erb
@@ -48,7 +48,7 @@
               <div class="panel panel-info">
                   <div class="panel-body camp-index">
                       <% if camp.images.any? %>
-                          <%= image_tag(camp.images.first.attachment.url(:square), :class => "grow") %>
+                          <%= image_tag(camp.default_image.attachment.url(:square), :class => "grow") %>
                       <% else %>
                           <%= image_tag('bsb_placeholder_square.jpg' , :class => "grow") %>
                       <% end %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -6,6 +6,7 @@
 
     <div class="col-md-8">
         <div class="row">
+            <% default_image_id = Camp.find(@camp_id).default_image_id %>
             <% @images&.each do |image| %>
                 <div class="camp-image">
                     <% image_url = image.attachment.url(:medium) %>
@@ -14,12 +15,8 @@
                         <%= form.submit t(:remove_image), { class: 'delete_button' } %>
                     <% end %>
                     <% if @camp_id.present? %>
-                        <%= button_to t(:set_default_image), set_default_image_camp_image_path(image.camp_id, image), {class: 'toggle_button'} %>
-                        <% if false %>
-                           <%= form_for [Camp.find(@camp_id), image], url: camp_path(@camp_id), method: :set_default_image do |form| %>
-                               <%= form.submit t(:set_default_image), { class: 'toggle_button' } %>
-                           <% end %>
-                        <% end %>
+                        <% is_default = (image.id == default_image_id) %>
+                        <%= button_to t(:set_default_image), set_default_image_camp_image_path(image.camp_id, image), {class: 'toggle_button', :disabled => is_default} %>
                     <% end %>
                 </div>
             <% end %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -13,6 +13,14 @@
                     <%= form_for image, url: camp_image_path(image.camp_id, image),  method: :delete do |form| %>
                         <%= form.submit t(:remove_image), { class: 'delete_button' } %>
                     <% end %>
+                    <% if @camp_id.present? %>
+                        <%= button_to t(:set_default_image), set_default_image_camp_image_path(image.camp_id, image), {class: 'toggle_button'} %>
+                        <% if false %>
+                           <%= form_for [Camp.find(@camp_id), image], url: camp_path(@camp_id), method: :set_default_image do |form| %>
+                               <%= form.submit t(:set_default_image), { class: 'toggle_button' } %>
+                           <% end %>
+                        <% end %>
+                    <% end %>
                 </div>
             <% end %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -439,6 +439,7 @@ en:
     Please make sure you own the required copyright for the uploaded images.
   upload_button: Upload Image
   remove_image: Remove Image
+  set_default_image: Set As Default
   back_to_dream: Back to dream
   error_no_image_selected: No image selected
   fully_funded: Fully funded

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
   }
   
   resources :camps, :path => 'dreams' do
-    resources :images
+    resources :images do
+      post 'set_default_image', on: :member
+    end
+
     resources :people, only: [:show, :update]
     post 'join', on: :member
     

--- a/db/migrate/20180108193521_add_default_image_id_to_camp.rb
+++ b/db/migrate/20180108193521_add_default_image_id_to_camp.rb
@@ -1,0 +1,15 @@
+class AddDefaultImageIdToCamp < ActiveRecord::Migration
+  def up
+    add_column :camps, :default_image_id, :integer
+
+    Camp.all.each do |cmp|
+      say_with_time("Setting default image for camp #{cmp.id}") do
+        cmp.update(:default_image_id => cmp.images.first.id) unless cmp.images.empty?
+      end
+    end
+  end
+
+  def down
+    remove_column :camps, :default_image_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171223171934) do
+ActiveRecord::Schema.define(version: 20180108193521) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     :index=>{:name=>"index_active_admin_comments_on_namespace"}
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 20171223171934) do
     t.string   "scholarship_receiver_bank_account_number"
     t.string   "scholarship_receiver_contact_email"
     t.string   "scholarship_receiver_contact_phone"
+    t.integer  "default_image_id"
   end
 
   create_table "grants", force: :cascade do |t|


### PR DESCRIPTION
Adds `default_image_id` for `Camp` and migrates the first image of each camp into this (This is what is used by default now)

Adds the ability to choose which image is the default for the project:
![dreams_choose_default_image](https://user-images.githubusercontent.com/3123328/34690715-dba21756-f4c2-11e7-963d-f235b38515e2.png)
