### PR TITLE
Fix default image missing

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -21,6 +21,8 @@ class ImagesController < ApplicationController
     @image.user_id = current_user.id
 
     if @image.save
+      cmp = Camp.find(camp_id)
+      cmp.update(:default_image => @image) unless cmp.default_image.present?
       redirect_to camp_images_path(camp_id: @camp_id)
     else
       render action: 'index'

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -35,6 +35,15 @@ class ImagesController < ApplicationController
     @image.save!
     @image.destroy!
 
+    cmp = Camp.find(camp_id)
+    if cmp.default_image_id == @image.id
+      if cmp.images.any?
+        cmp.update(:default_image => cmp.images.first)
+      else
+        cmp.update(:default_image_id => nil)
+      end
+    end
+
     redirect_to camp_images_path(camp_id: @camp_id)
   end
 

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -15,12 +15,8 @@
         </div>
 
         <div id="links">
+            <% @mainImage = @camp.default_image.attachment.url(:large) %>
             <% @camp.images.each_with_index do |image, index| %>
-                <% status = "" %>
-                <% if index == 0 %>
-                    <% status = "active" %>
-                    <% @mainImage = image.attachment.url(:large) %>
-                <% end %>
                 <% image_url = image.attachment.url(:large)%>
                 <% thumb_url = image.attachment.url(:medium)%>
 


### PR DESCRIPTION
Fixing the problem that default image for a dream won't be set after the first image is added or the old default is deleted.

Also using the default image as the main background for the dream page.