### PR TITLE
adding dreams export button

### DIFF
--- a/app/controllers/camps_controller.rb
+++ b/app/controllers/camps_controller.rb
@@ -1,6 +1,6 @@
 class CampsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :load_camp!, except: [:index, :new, :create]
+  before_action :load_camp!, except: [:index, :new, :create, :export_csv]
   before_action :enforce_delete_permission!, only: [:destroy, :archive]
   before_action :enforce_guide!, only: %i(tag)
   before_action :enforce_grant_lockdown!, only: %i(update_grants)
@@ -275,6 +275,15 @@ class CampsController < ApplicationController
   def archive
     @camp.update!(active: false)
     redirect_to camps_path
+  end
+
+  def export_csv
+    unless current_user.admin
+      redirect_to root_path
+      return
+    end
+
+    send_data Camp.all.to_csv, :filename => "dreams-#{Date.today}.csv"
   end
 
   private

--- a/app/models/camp.rb
+++ b/app/models/camp.rb
@@ -201,4 +201,15 @@ class Camp < ActiveRecord::Base
       self.maxbudget = 0
     end
   end
+
+  CSV_ATTRIBUTES = %w{dream_name dream_id crewsize}.freeze
+
+  def self.to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << CSV_ATTRIBUTES.map{ |attr| attr.titleize}
+      Camp.where(:event_id => Rails.application.config.default_event, :is_public => true).each do |c|
+        csv << [c.en_name, c.id, c.safetybag_crewsize]
+      end
+    end
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -39,6 +39,7 @@
             <% end %>
             <% if user_signed_in? and current_user.admin %>
                 <%= link_to t(:export_people), people_export_path %>
+                <%= link_to t(:export_dreams), export_camps_path %>
             <% end %>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
   my_area: Me
   logout_menu: Log out
   export_people: Export People
+  export_dreams: Export Dreams
   public: Public
   humans_credit_html: The dreams platform started at Borderland, from there it reached
     the Middle east to Midburnerot and now Midburn<br>Here are the humans who made

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -49,6 +49,7 @@ he:
   logout_menu: "התנתקי"
 
   export_people: "דוח אנשים"
+  export_dreams: "דוח חלומות"
 
   public: "פומבי"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   }
   
   resources :camps, :path => 'dreams' do
+    get 'export', on: :collection, to: 'camps#export_csv'
+
     resources :images do
       post 'set_default_image', on: :member
     end

--- a/spec/models/camp_spec.rb
+++ b/spec/models/camp_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+require 'faker'
+I18n.reload!
+
+describe Person do
+  let(:email) { Faker::Internet.email }
+  let(:creator) { User.create! email: email, password: Faker::Internet.password, ticket_id: '6687' }
+  let(:firestarter) { Role.create!(:identifier => "firestarter") }
+
+  let(:camp) do
+    Camp.create!(
+      :name               => 'Burn something',
+      :en_name            => 'Burn something english',
+      :subtitle           => 'Subtitle',
+      :description        => 'We will build something and then burn it',
+      :electricity        => 'Big enough for a big fire',
+      :light              => 'There sill be need of good ventilation',
+      :fire               => '2 to build and 3 to burn',
+      :noise              => 'The fire consumes everything',
+      :nature             => 'Well - it will burn....',
+      :contact_email      => 'burn@example.com',
+      :contact_name       => Faker::Name.name,
+      :creator            => creator,
+      :is_public          => true,
+      :safetybag_crewsize => 3,
+      :event_id           => "current_event"
+    )
+  end
+
+  let!(:john) { Person.create!(
+      :name                => Faker::Name.name,
+      :email               => Faker::Internet.email,
+      :phone_number        => Faker::PhoneNumber.phone_number,
+      :needs_early_arrival => true,
+      :has_ticket          => false,
+      :camp_id             => camp.id,
+      :roles               => [firestarter,]
+    )
+  }
+
+  before :each do
+    allow(Rails.application.config)
+      .to receive(:default_event)
+      .and_return("current_event")
+  end
+
+  describe "#self.to_csv" do
+    context "one dream" do
+      it "shows a dream from current event" do
+        csv_lines = Camp.to_csv.split("\n")
+        expect(csv_lines.count).to eq(2)
+        expect(csv_lines.last.split(",")).to eq([camp.en_name,
+                                                 camp.id.to_s,
+                                                 camp.safetybag_crewsize.to_s])
+      end
+
+      it "shows a dream from current event" do
+        camp.update(:is_public => false)
+        csv_lines = Camp.to_csv.split("\n")
+        expect(csv_lines.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding a button that is only seen by admin to export dreams
through the 'dreams/export' endpoint that is also only available to
admins.

The exported file is a CSV with fields defined in app/modes/camp.rb