### PR TITLE
Adding camp manager association to camp

### DIFF
--- a/app/controllers/camps_controller.rb
+++ b/app/controllers/camps_controller.rb
@@ -44,14 +44,14 @@ class CampsController < ApplicationController
     # Create camp without people then add them
     @camp = Camp.new(camp_params)
     @camp.creator = current_user
-
-    if create_camp
+    if @camp.people.first.present? and create_camp
+      @camp.update(:camp_manager_id => @camp.people.first.id)
       flash[:notice] = t('created_new_dream')
-      redirect_to edit_camp_path(id: @camp.id)
-    else
-      flash.now[:notice] = "#{t:errors_str}: #{@camp.errors.full_messages.uniq.join(', ')}"
-      render :new
+      return redirect_to edit_camp_path(id: @camp.id)
     end
+
+    flash.now[:notice] = "#{t:errors_str}: #{@camp.errors.full_messages.uniq.join(', ')}"
+    render :new
   end
 
   # Toggle granting

--- a/app/models/camp.rb
+++ b/app/models/camp.rb
@@ -12,9 +12,10 @@ class Camp < ActiveRecord::Base
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
   has_many :images #, :dependent => :destroy
-  belongs_to :default_image, :class_name => "Image", :foreign_key => :default_image_id
+  belongs_to :default_image, class_name: 'Image', foreign_key: :default_image_id
   has_many :grants
   has_many :people, class_name: 'Person'
+  belongs_to :camp_manager, class_name: 'Person', foreign_key: :camp_manager_id
   has_many :roles, through: :people
   has_many :setup_steps, class_name: :CampSetupStep
 

--- a/app/views/camps/_form.haml
+++ b/app/views/camps/_form.haml
@@ -354,7 +354,7 @@
     .row
       .col-xs-12
         .admin_details#admin_details
-          = form.fields_for :people, @camp.people.first do |person|
+          = form.fields_for :people, @camp.camp_manager do |person|
             = render 'person_fields', :f => person, :camp_id => @camp.id, :dream_admin => true
 
     .h3
@@ -373,7 +373,7 @@
         = t("form_project_management_crew_desc")
     
     #responsibles
-      = form.fields_for :people, @camp.people[1..-1] do |person|
+      = form.fields_for :people, @camp.people.where.not(:id => @camp.camp_manager_id) do |person|
         = render 'person_fields', :f => person, :camp_id => @camp.id
     
     - if @can_edit

--- a/db/migrate/20180219103255_add_camp_manager_id_to_camp.rb
+++ b/db/migrate/20180219103255_add_camp_manager_id_to_camp.rb
@@ -1,0 +1,15 @@
+class AddCampManagerIdToCamp < ActiveRecord::Migration
+  def up
+    add_column :camps, :camp_manager_id, :integer
+
+    Camp.all.each do |cmp|
+      say_with_time("Setting camp_manager_id for camp #{cmp.id}") do
+        cmp.update(:camp_manager_id => cmp.people.first.id) unless cmp.people.empty?
+      end
+    end
+  end
+
+  def down
+    remove_column :camps, :camp_manager_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215211947) do
+ActiveRecord::Schema.define(version: 20180219103255) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     :index=>{:name=>"index_active_admin_comments_on_namespace"}
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 20180215211947) do
     t.string   "scholarship_receiver_contact_email"
     t.string   "scholarship_receiver_contact_phone"
     t.integer  "default_image_id"
+    t.integer  "camp_manager_id"
   end
 
   create_table "grants", force: :cascade do |t|

--- a/spec/controllers/camps_controller_spec.rb
+++ b/spec/controllers/camps_controller_spec.rb
@@ -20,7 +20,8 @@ describe CampsController do
         noise: 'The fire consumes everything',
         nature: 'Well - it will burn....',
         contact_email: 'burn@example.com',
-        contact_name: camp_leader
+        contact_name: camp_leader,
+        people_attributes: {'0' => {name: Faker::Name.name}}
     }
   }
 
@@ -41,6 +42,12 @@ describe CampsController do
       c = Camp.find_by_contact_name camp_leader
 
       expect( c.name ).to eq 'Burn something'
+    end
+
+    it 'won\'t create a camp without manager' do
+      post :create, camp: camp_attributes.merge!(people_attributes: {})
+      expect(Camp.find_by_contact_name(camp_leader)).to be_nil
+      expect(flash[:notice]).to_not be_nil
     end
   end
 


### PR DESCRIPTION
Fixing hidden camp crew issue by adding camp_manager_id to camp
and makeing sure it is set for all camps.

Fixes #267 