### PR TITLE
refactor 'displayed' scope with camp_manager_id

### DIFF
--- a/app/admin/camps.rb
+++ b/app/admin/camps.rb
@@ -2,12 +2,12 @@ ActiveAdmin.register Camp do
   EXCLUDED = %w(contact_email user_id seeking_members safetybag_firstMemberName safetybag_firstMemberEmail safetybag_secondMemberName safetybag_secondMemberEmail)
 
   scope :active, default: true do |dreams|
-      dreams.active(true)
+      dreams.displayed.where(active: true)
     end
   scope :displayed_with_tags, default: false
-  scope("Public") { |scope| scope.where(is_public: true) }
-  scope("Private") { |scope| scope.where(is_public: false) }
-  scope("Inactive") { |scope| scope.where(active: false) }
+  scope("Public") { |dreams| dreams.displayed.where(is_public: true) }
+  scope("Private") { |dreams| dreams.displayed.where(is_public: false) }
+  scope("Inactive") { |dreams| dreams.displayed.where(active: false) }
   
   remove_filter *%i(tag_taggings taggings base_tags)
   index do

--- a/app/models/camp.rb
+++ b/app/models/camp.rb
@@ -145,10 +145,8 @@ class Camp < ActiveRecord::Base
   }
 
   scope :displayed, -> {
-    q = default_select.joins("LEFT JOIN roles ON (roles.identifier = '#{:manager}')")
-            .joins("LEFT JOIN people ON (people.camp_id = camps.id)")
-            .joins("LEFT JOIN people_roles pr ON (pr.role_id = roles.id)")
-            .where('people.id = pr.person_id')
+    q = default_select.joins(:people)
+      .where('people.id = camps.camp_manager_id')
     
     if connection.adapter_name == 'SQLite'
       q.select('people.name manager_name, people.email manager_email, people.phone_number manager_phone')

--- a/spec/models/camp_spec.rb
+++ b/spec/models/camp_spec.rb
@@ -44,6 +44,17 @@ describe Person do
       .and_return("current_event")
   end
 
+  describe "#displayed scop" do
+    it "displays camp" do
+      camp.update(camp_manager: john)
+      expect(Camp.displayed).to eq([camp])
+    end
+
+    it "doesn't display manager-less camps" do
+      expect(Camp.displayed).to be_empty
+    end
+  end
+
   describe "#self.to_csv" do
     context "one dream" do
       it "shows a dream from current event" do


### PR DESCRIPTION
This will use the `camp_manager_id` column for the `displayed`  and will then use `displayed` for all scopes that the admin sees to add the array aggregations to them. 