### PR TITLE
set deadlines for midburn 2019 start

### DIFF
--- a/config/lockdown.yml
+++ b/config/lockdown.yml
@@ -1,7 +1,7 @@
 common: &common
-  submit_dream: 2018-01-14t00:00:00+02:00
-  safety_file: 2018-03-04t00:00:00+02:00
-  vote_hearts: 2018-03-04t00:00:00+02:00 #No hearts this year
+  submit_dream: 2019-06-05t00:00:00+02:00
+  safety_file: 2019-06-05t00:00:00+02:00
+  vote_hearts: 2019-06-05t00:00:00+02:00 #No hearts this year
 
 development:
   <<: *common


### PR DESCRIPTION
This project uses Lockdown gem to set some deadlines, you can see at [1] that it asks Lockdown if it can show this button (even if the two environment variables that exist for it are false)


[1] https://github.com/Midburn/Dreams/blob/master/app/views/shared/_header.html.erb#L23